### PR TITLE
Fixed line ending in aml-workspace - fixes #11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,48 @@
-# Set the default behavior, in case people don't have core.autocrlf set.
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
 * text=auto
 
-# Explicitly declare text files you want to always be normalized and converted
-# to native line endings on checkout.
-*.yml text
-Dockerfile text
-*md text
+###############################################################################
+# Set the merge driver for project and solution files
+###############################################################################
+*.sh        text eol=lf
+*.py        text eol=lf diff=python
+*.json      text
+*.yaml      text
+*.yml       text
+Dockerfile  text
 
-# declare files with line ending lf (line feed/ no carriage return)
-*.sh text eol=lf
-*.py text eol=lf
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+*.jpg   binary
+*.png   binary
+*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+*.doc   diff=astextplain
+*.DOC   diff=astextplain
+*.docx  diff=astextplain
+*.DOCX  diff=astextplain
+*.dot   diff=astextplain
+*.DOT   diff=astextplain
+*.pdf   diff=astextplain
+*.PDF   diff=astextplain
+*.rtf   diff=astextplain
+*.RTF   diff=astextplain
+*.md    text
+
+###############################################################################
+# Exclude files from exporting
+###############################################################################
+.gitattributes  export-ignore
+.gitignore      export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.yml text
+Dockerfile text
+*md text
+
+# declare files with line ending lf (line feed/ no carriage return)
+*.sh text eol=lf
+*.py text eol=lf

--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ The action writes the workspace Azure Resource Manager (ARM) properties to a con
 - [aml-registermodel](https://github.com/Azure/aml-registermodel) - Registers a model to Azure Machine Learning
 - [aml-deploy](https://github.com/Azure/aml-deploy) - Deploys a model and creates an endpoint for the model
 
+### Known issues
+
+#### Error: MissingSubscriptionRegistration
+
+Error message: 
+```sh
+Message: ***'error': ***'code': 'MissingSubscriptionRegistration', 'message': "The subscription is not registered to use namespace 'Microsoft.KeyVault'. See https://aka.ms/rps-not-found for how to register subscriptions.", 'details': [***'code': 'MissingSubscriptionRegistration', 'target': 'Microsoft.KeyVault', 'message': "The subscription is not registered to use namespace 'Microsoft.KeyVault'. See https://aka.ms/rps-not-found for how to register subscriptions
+```
+Solution:
+
+This error message appears, in case the `Azure/aml-workspace` action tries to create a new Azure Machine Learning workspace in your resource group and you have never deployed a Key Vault in the subscription before. We recommend to create an Azure Machine Learning workspace manually in the Azure Portal. Follow the [steps on this website](https://docs.microsoft.com/en-us/azure/machine-learning/tutorial-1st-experiment-sdk-setup#create-a-workspace) to create a new workspace with the desired name. After ou have successfully completed the steps, you have to make sure, that your Service Principal has access to the resource group and that the details in your <a href="/.cloud/.azure/workspace.json">`/.cloud/.azure/workspace.json"` file</a> are correct and point to the right workspace and resource group.
+
 ### Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
@@ -140,4 +152,3 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-

--- a/code/entrypoint.sh
+++ b/code/entrypoint.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-ls -la code
 python /code/main.py


### PR DESCRIPTION
## Wrong line ending stops container from running ##
Fix for issue #11 

### Purpose of this PR is
to prevent container for stopping when running entrypoint shell 'entrypoint.sh'

### Error description
running the container leads to stop with error stating "ls: no such file or directory"

### Cause
files in repository are checked in with CRLF line ending (\r\n) which is not supported in Linux OS.
The Docker container, that is build is based on Ubuntu Linux.

### Solution
handling file line endings (CR/LF) by adding a .gitattributes file, with rules regarding line endings for different file types